### PR TITLE
#1 Add --request-file option for file/directory path input

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -47,9 +47,7 @@ def main() -> None:
         else:
             files = sorted(p for p in request_path.iterdir() if p.is_file())
             if not files:
-                parser.error(
-                    f"ディレクトリにファイルがありません: {args.request_file}"
-                )
+                parser.error(f"ディレクトリにファイルがありません: {args.request_file}")
             parts = []
             for f in files:
                 parts.append(f"# {f.name}\n{f.read_text(encoding='utf-8')}")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -61,36 +61,49 @@ class TestRequestOption:
         req_file = tmp_path / "request.md"
         req_file.write_text("要求", encoding="utf-8")
 
-        with patch(
-            "sys.argv",
-            [
-                "prog",
-                "--request", "テスト",
-                "--request-file", str(req_file),
-                "--source", source_dir,
-            ],
-        ), pytest.raises(SystemExit, match="2"):
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "prog",
+                    "--request",
+                    "テスト",
+                    "--request-file",
+                    str(req_file),
+                    "--source",
+                    source_dir,
+                ],
+            ),
+            pytest.raises(SystemExit, match="2"),
+        ):
             main()
 
     def test_neither_option_error(self, source_dir):
-        with patch("sys.argv", ["prog", "--source", source_dir]), pytest.raises(
-            SystemExit, match="2"
+        with (
+            patch("sys.argv", ["prog", "--source", source_dir]),
+            pytest.raises(SystemExit, match="2"),
         ):
             main()
 
     def test_nonexistent_file_error(self, source_dir):
-        with patch(
-            "sys.argv",
-            ["prog", "--request-file", "/nonexistent/path.md", "--source", source_dir],
-        ), pytest.raises(SystemExit, match="2"):
+        with (
+            patch(
+                "sys.argv",
+                ["prog", "--request-file", "/nonexistent/path.md", "--source", source_dir],
+            ),
+            pytest.raises(SystemExit, match="2"),
+        ):
             main()
 
     def test_empty_directory_error(self, tmp_path, source_dir):
         empty_dir = tmp_path / "empty"
         empty_dir.mkdir()
 
-        with patch(
-            "sys.argv",
-            ["prog", "--request-file", str(empty_dir), "--source", source_dir],
-        ), pytest.raises(SystemExit, match="2"):
+        with (
+            patch(
+                "sys.argv",
+                ["prog", "--request-file", str(empty_dir), "--source", source_dir],
+            ),
+            pytest.raises(SystemExit, match="2"),
+        ):
             main()


### PR DESCRIPTION
## Summary

- `--request-file` オプションを追加。改修要求をファイルパスまたはディレクトリパスで指定可能に
- ファイル指定時: そのまま読み込み
- ディレクトリ指定時: 配下のファイルをソート順で結合（ファイル名ヘッダー付き）
- `--request` と `--request-file` は排他（`mutually_exclusive_group`）
- 存在しないパス・空ディレクトリはエラー

Closes #1

## Changes

- `src/main.py` — argparse に `--request-file` オプション追加、ファイル/ディレクトリ読み込みロジック
- `tests/test_main.py` — 新規作成。正常系3件 + 異常系4件 = 計7テスト

## Test plan

- [x] `--request` のみ指定 → 正常動作
- [x] `--request-file` に単一ファイル → 内容が読み込まれる
- [x] `--request-file` にディレクトリ → 配下ファイルが結合される
- [x] 両方指定 → エラー
- [x] どちらも未指定 → エラー
- [x] 存在しないパス → エラー
- [x] 空ディレクトリ → エラー
- [x] ruff lint: All checks passed
- [x] bandit: No issues identified
- [x] pytest: 21 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)