### PR TITLE
#19 Improve discussion round display and pipeline completion summary

### DIFF
--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -281,8 +281,17 @@ def _run_engineer_phase(
 
     # 議論ラウンド
     for round_num in range(config.max_discussion_rounds):
-        _emit(on_event, "discussion_round", agent="engineer", round=round_num + 1)
-        _tprint(f"  Engineer 議論ラウンド {round_num + 1}...")
+        _emit(
+            on_event,
+            "discussion_round",
+            agent="engineer",
+            round=round_num + 1,
+            total_rounds=config.max_discussion_rounds,
+            agent_count=n,
+        )
+        _tprint(
+            f"  Engineer 議論ラウンド {round_num + 1}/{config.max_discussion_rounds} ({n}人)..."
+        )
 
         new_outputs: list[EngineerOutput] = []
         for i in range(n):
@@ -441,8 +450,17 @@ def _run_reviewer_phase(
 
     # 議論ラウンド
     for round_num in range(config.max_discussion_rounds):
-        _emit(on_event, "discussion_round", agent="reviewer", round=round_num + 1)
-        _tprint(f"  Reviewer 議論ラウンド {round_num + 1}...")
+        _emit(
+            on_event,
+            "discussion_round",
+            agent="reviewer",
+            round=round_num + 1,
+            total_rounds=config.max_discussion_rounds,
+            agent_count=n,
+        )
+        _tprint(
+            f"  Reviewer 議論ラウンド {round_num + 1}/{config.max_discussion_rounds} ({n}人)..."
+        )
 
         new_outputs: list[ReviewerOutput] = []
         for i in range(n):
@@ -860,7 +878,16 @@ def run_pipeline(
         _tprint(f"\n⚠️ 差し戻し上限 ({max_att}) に到達。最終結果で出力します。")
 
     logger.write_summary()
-    _emit(on_event, "pipeline_complete")
+
+    # パイプライン完了サマリを構築
+    summary_data: dict = {
+        "steps": step_counter[0],
+        "output_dir": str(logger.run_dir),
+    }
+    if rev_output:
+        summary_data["review_result"] = rev_output.review_result
+        summary_data["issues"] = rev_output.issues
+    _emit(on_event, "pipeline_complete", **summary_data)
 
     if rev_output:
         result_label = "✅ PASS" if rev_output.review_result == "PASS" else "❌ FAIL"

--- a/src/web/static/index.html
+++ b/src/web/static/index.html
@@ -799,12 +799,19 @@ async function startRun() {
           removeTyping();
           showApprovalDialog(event.data);
           break;
-        case "discussion_round":
-          addSystemMessage(`${agentKey} 議論ラウンド ${event.data.round || "?"}`);
+        case "discussion_round": {
+          const r = event.data.round || "?";
+          const total = event.data.total_rounds || "?";
+          const cnt = event.data.agent_count || "?";
+          const role = agentKey === "engineer" ? "Engineer" : "Reviewer";
+          addSystemMessage(`💬 ${role} 議論ラウンド ${r}/${total}（${cnt}人が相互レビュー中）`);
           break;
-        case "discussion_converged":
-          addSystemMessage(`${agentKey} の議論が収束しました`);
+        }
+        case "discussion_converged": {
+          const role2 = agentKey === "engineer" ? "Engineer" : "Reviewer";
+          addSystemMessage(`✅ ${role2} の議論が収束しました — 合意に到達`);
           break;
+        }
         case "pm_tiebreak":
           addSystemMessage("PM が裁定を行います...");
           showTyping("pm");
@@ -829,12 +836,28 @@ async function startRun() {
         case "review_fail_retry":
           addSystemMessage(`レビューFAIL → 修正指示で再実行 (${event.data.attempt || "?"}回目)`);
           break;
-        case "pipeline_complete":
-          addSystemMessage("パイプライン完了");
+        case "pipeline_complete": {
+          removeTyping();
+          const d = event.data;
+          const result = d.review_result;
+          const badge = result === "PASS" ? "✅ PASS" : result === "FAIL" ? "❌ FAIL" : "";
+          let summaryHtml = `<strong>パイプライン完了</strong>`;
+          if (badge) summaryHtml += ` — ${badge}`;
+          if (d.steps) summaryHtml += `<br>ステップ数: ${d.steps}`;
+          if (d.issues && d.issues.length > 0) {
+            summaryHtml += `<br>指摘事項: ${d.issues.length}件`;
+          }
+          if (d.output_dir) summaryHtml += `<br>出力: ${d.output_dir}`;
+          const div = document.createElement("div");
+          div.className = "system-msg";
+          div.innerHTML = summaryHtml;
+          chatArea.appendChild(div);
+          scrollToBottom();
           eventSource.close();
           btn.disabled = false;
           currentRunId = null;
           break;
+        }
         case "pipeline_error":
           removeTyping();
           addSystemMessage("エラー: " + (event.data.error || "不明なエラー"));


### PR DESCRIPTION
## Summary

- 議論ラウンドの表示を改善（ラウンド数/総数、参加人数を表示）
- 議論収束時に視覚的なインジケータ付きメッセージを表示
- パイプライン完了時にサマリ情報を表示（レビュー結果、ステップ数、指摘件数、出力先）

## Changes

### Backend (`src/pipeline.py`)
- `discussion_round` イベントに `total_rounds`, `agent_count` を追加
- `pipeline_complete` イベントに `review_result`, `steps`, `issues`, `output_dir` を追加

### Frontend (`src/web/static/index.html`)
- 議論ラウンド: `💬 Engineer 議論ラウンド 1/2（4人が相互レビュー中）`
- 議論収束: `✅ Engineer の議論が収束しました — 合意に到達`
- パイプライン完了: レビュー結果・ステップ数・指摘件数・出力先を表示

## Test plan

- [x] `ruff format --check` / `ruff check` パス
- [x] `pytest tests/` 全74テスト合格
- [x] Web UIで議論ラウンドの詳細表示を確認
- [ ] パイプライン完了時のサマリ表示を確認

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)